### PR TITLE
For issue 12

### DIFF
--- a/Pechkin/GlobalConfig.cs
+++ b/Pechkin/GlobalConfig.cs
@@ -11,6 +11,7 @@ namespace Pechkin
     /// 
     /// It uses fluid notation to change its fields.
     /// </summary>
+    [Serializable]
     public class GlobalConfig
     {
         private string _paperSize = "A4";
@@ -332,99 +333,99 @@ namespace Pechkin
 
             if (_paperSize != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "size.paperSize", _paperSize);
+                PechkinStatic.SetGlobalSetting(config, "size.paperSize", _paperSize);
             }
             if (_paperWidth != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "size.width", _paperWidth);
+                PechkinStatic.SetGlobalSetting(config, "size.width", _paperWidth);
             }
             if (_paperHeight != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "size.height", _paperHeight);
+                PechkinStatic.SetGlobalSetting(config, "size.height", _paperHeight);
             }
             if (_paperOrientation != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "orientation", _paperOrientation);
+                PechkinStatic.SetGlobalSetting(config, "orientation", _paperOrientation);
             }
             if (_colorMode != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "colorMode", _colorMode);
+                PechkinStatic.SetGlobalSetting(config, "colorMode", _colorMode);
             }
             if (_resolution != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "resolution", _resolution);
+                PechkinStatic.SetGlobalSetting(config, "resolution", _resolution);
             }
             if (_dpi != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "dpi", _dpi);
+                PechkinStatic.SetGlobalSetting(config, "dpi", _dpi);
             }
             if (_pageOffset != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "pageOffset", _pageOffset);
+                PechkinStatic.SetGlobalSetting(config, "pageOffset", _pageOffset);
             }
             if (_copies != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "copies", _copies);
+                PechkinStatic.SetGlobalSetting(config, "copies", _copies);
             }
             if (_collate != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "collate", _collate);
+                PechkinStatic.SetGlobalSetting(config, "collate", _collate);
             }
             if (_outline != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "outline", _outline);
+                PechkinStatic.SetGlobalSetting(config, "outline", _outline);
             }
             if (_outlineDepth != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "outlineDepth", _outlineDepth);
+                PechkinStatic.SetGlobalSetting(config, "outlineDepth", _outlineDepth);
             }
             if (_dumpOutline != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "dumpOutline", _dumpOutline);
+                PechkinStatic.SetGlobalSetting(config, "dumpOutline", _dumpOutline);
             }
             if (_output != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "out", _output);
+                PechkinStatic.SetGlobalSetting(config, "out", _output);
             }
             if (_documentTitle != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "documentTitle", _documentTitle);
+                PechkinStatic.SetGlobalSetting(config, "documentTitle", _documentTitle);
             }
             if (_useCompression != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "useCompression", _useCompression);
+                PechkinStatic.SetGlobalSetting(config, "useCompression", _useCompression);
             }
             if (_marginTop != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "margin.top", _marginTop);
+                PechkinStatic.SetGlobalSetting(config, "margin.top", _marginTop);
             }
             if (_marginRight != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "margin.right", _marginRight);
+                PechkinStatic.SetGlobalSetting(config, "margin.right", _marginRight);
             }
             if (_marginBottom != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "margin.bottom", _marginBottom);
+                PechkinStatic.SetGlobalSetting(config, "margin.bottom", _marginBottom);
             }
             if (_marginLeft != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "margin.left", _marginLeft);
+                PechkinStatic.SetGlobalSetting(config, "margin.left", _marginLeft);
             }
             if (_outputFormat != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "outputFormat", _outputFormat);
+                PechkinStatic.SetGlobalSetting(config, "outputFormat", _outputFormat);
             }
             if (_imageDpi != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "imageDPI", _imageDpi);
+                PechkinStatic.SetGlobalSetting(config, "imageDPI", _imageDpi);
             }
             if (_imageQuality != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "imageQuality", _imageQuality);
+                PechkinStatic.SetGlobalSetting(config, "imageQuality", _imageQuality);
             }
             if (_cookieJar != null)
             {
-                PechkinBindings.wkhtmltopdf_set_global_setting(config, "load.cookieJar", _cookieJar);
+                PechkinStatic.SetGlobalSetting(config, "load.cookieJar", _cookieJar);
             }
         }
 

--- a/Pechkin/ObjectConfig.cs
+++ b/Pechkin/ObjectConfig.cs
@@ -13,6 +13,7 @@ namespace Pechkin
     /// You will find that there's no page body for conversion of pages that are in memory.
     /// Instead the page body is supplied into the <code>Convert</code> method of the converter.
     /// </summary>
+    [Serializable]
     public class ObjectConfig
     {
         public class HeaderSettings
@@ -175,35 +176,35 @@ namespace Pechkin
             {
                 if (_fontSize != null)
                 {
-                    PechkinBindings.wkhtmltopdf_set_object_setting(config, prefix + "." + "fontSize", _fontSize);
+                    PechkinStatic.SetObjectSetting(config, prefix + "." + "fontSize", _fontSize);
                 }
                 if (_fontName != null)
                 {
-                    PechkinBindings.wkhtmltopdf_set_object_setting(config, prefix + "." + "fontName", _fontName);
+                    PechkinStatic.SetObjectSetting(config, prefix + "." + "fontName", _fontName);
                 }
                 if (_leftText != null)
                 {
-                    PechkinBindings.wkhtmltopdf_set_object_setting(config, prefix + "." + "left", _leftText);
+                    PechkinStatic.SetObjectSetting(config, prefix + "." + "left", _leftText);
                 }
                 if (_centerText != null)
                 {
-                    PechkinBindings.wkhtmltopdf_set_object_setting(config, prefix + "." + "center", _centerText);
+                    PechkinStatic.SetObjectSetting(config, prefix + "." + "center", _centerText);
                 }
                 if (_rightText != null)
                 {
-                    PechkinBindings.wkhtmltopdf_set_object_setting(config, prefix + "." + "right", _rightText);
+                    PechkinStatic.SetObjectSetting(config, prefix + "." + "right", _rightText);
                 }
                 if (_lineSeparator != null)
                 {
-                    PechkinBindings.wkhtmltopdf_set_object_setting(config, prefix + "." + "line", _lineSeparator);
+                    PechkinStatic.SetObjectSetting(config, prefix + "." + "line", _lineSeparator);
                 }
                 if (_space != null)
                 {
-                    PechkinBindings.wkhtmltopdf_set_object_setting(config, prefix + "." + "space", _space);
+                    PechkinStatic.SetObjectSetting(config, prefix + "." + "space", _space);
                 }
                 if (_htmlUrl != null)
                 {
-                    PechkinBindings.wkhtmltopdf_set_object_setting(config, prefix + "." + "htmlUrl", _htmlUrl);
+                    PechkinStatic.SetObjectSetting(config, prefix + "." + "htmlUrl", _htmlUrl);
                 }
             }
         }
@@ -684,135 +685,135 @@ namespace Pechkin
 
             if (_tocUseDottedLines != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "toc.useDottedLines", _tocUseDottedLines);
+                PechkinStatic.SetObjectSetting(config, "toc.useDottedLines", _tocUseDottedLines);
             }
             if (_tocCaption != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "toc.captionText", _tocCaption);
+                PechkinStatic.SetObjectSetting(config, "toc.captionText", _tocCaption);
             }
             if (_tocCreateLinks != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "toc.forwardLinks", _tocCreateLinks);
+                PechkinStatic.SetObjectSetting(config, "toc.forwardLinks", _tocCreateLinks);
             }
             if (_tocBackLinks != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "toc.backLinks", _tocBackLinks);
+                PechkinStatic.SetObjectSetting(config, "toc.backLinks", _tocBackLinks);
             }
             if (_tocIndentation != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "toc.indentation", _tocIndentation);
+                PechkinStatic.SetObjectSetting(config, "toc.indentation", _tocIndentation);
             }
             if (_tocFontScale != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "toc.fontScale", _tocFontScale);
+                PechkinStatic.SetObjectSetting(config, "toc.fontScale", _tocFontScale);
             }
             if (_createToc != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "isTableOfContent", _createToc);
+                PechkinStatic.SetObjectSetting(config, "isTableOfContent", _createToc);
             }
             if (_includeInOutline != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "includeInOutline", _includeInOutline);
+                PechkinStatic.SetObjectSetting(config, "includeInOutline", _includeInOutline);
             }
             if (_pagesCount != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "pagesCount", _pagesCount);
+                PechkinStatic.SetObjectSetting(config, "pagesCount", _pagesCount);
             }
             if (_tocXsl != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "tocXsl", _tocXsl);
+                PechkinStatic.SetObjectSetting(config, "tocXsl", _tocXsl);
             }
             if (_pageUri != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "page", _pageUri);
+                PechkinStatic.SetObjectSetting(config, "page", _pageUri);
             }
             if (_useExternalLinks != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "useExternalLinks", _useExternalLinks);
+                PechkinStatic.SetObjectSetting(config, "useExternalLinks", _useExternalLinks);
             }
             if (_useLocalLinks != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "useLocalLinks", _useLocalLinks);
+                PechkinStatic.SetObjectSetting(config, "useLocalLinks", _useLocalLinks);
             }
             if (_produceForms != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "produceForms", _produceForms);
+                PechkinStatic.SetObjectSetting(config, "produceForms", _produceForms);
             }
             if (_loadUsername != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "load.username", _loadUsername);
+                PechkinStatic.SetObjectSetting(config, "load.username", _loadUsername);
             }
             if (_loadPassword != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "load.password", _loadPassword);
+                PechkinStatic.SetObjectSetting(config, "load.password", _loadPassword);
             }
             if (_loadJsDelay != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "load.jsdelay", _loadJsDelay);
+                PechkinStatic.SetObjectSetting(config, "load.jsdelay", _loadJsDelay);
             }
             if (_loadZoomFactor != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "load.zoomFactor", _loadZoomFactor);
+                PechkinStatic.SetObjectSetting(config, "load.zoomFactor", _loadZoomFactor);
             }
             if (_loadRepeatCustomHeaders != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "load.repertCustomHeaders", _loadRepeatCustomHeaders);
+                PechkinStatic.SetObjectSetting(config, "load.repertCustomHeaders", _loadRepeatCustomHeaders);
             }
             if (_loadBlockLocalFileAccess != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "load.blockLocalFileAccess", _loadBlockLocalFileAccess);
+                PechkinStatic.SetObjectSetting(config, "load.blockLocalFileAccess", _loadBlockLocalFileAccess);
             }
             if (_loadStopSlowScript != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "load.stopSlowScript", _loadStopSlowScript);
+                PechkinStatic.SetObjectSetting(config, "load.stopSlowScript", _loadStopSlowScript);
             }
             if (_loadDebugJavascript != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "load.debugJavascript", _loadDebugJavascript);
+                PechkinStatic.SetObjectSetting(config, "load.debugJavascript", _loadDebugJavascript);
             }
             if (_loadErrorHandling != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "load.loadErrorHandling", _loadErrorHandling);
+                PechkinStatic.SetObjectSetting(config, "load.loadErrorHandling", _loadErrorHandling);
             }
             if (_loadProxy != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "load.proxy", _loadProxy);
+                PechkinStatic.SetObjectSetting(config, "load.proxy", _loadProxy);
             }
             if (_webPrintBackground != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "web.background", _webPrintBackground);
+                PechkinStatic.SetObjectSetting(config, "web.background", _webPrintBackground);
             }
             if (_webLoadImages != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "web.loadImages", _webLoadImages);
+                PechkinStatic.SetObjectSetting(config, "web.loadImages", _webLoadImages);
             }
             if (_webRunJavascript != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "web.enableJavascript", _webRunJavascript);
+                PechkinStatic.SetObjectSetting(config, "web.enableJavascript", _webRunJavascript);
             }
             if (_webIntelligentShrinking != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "web.enableIntelligentShrinking", _webIntelligentShrinking);
+                PechkinStatic.SetObjectSetting(config, "web.enableIntelligentShrinking", _webIntelligentShrinking);
             }
             if (_webMinFontSize != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "web.minimumFontSize", _webMinFontSize);
+                PechkinStatic.SetObjectSetting(config, "web.minimumFontSize", _webMinFontSize);
             }
             if (_webPrintMediaType != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "web.printMediaType", _webPrintMediaType);
+                PechkinStatic.SetObjectSetting(config, "web.printMediaType", _webPrintMediaType);
             }
             if (_webDefaultEncoding != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "web.defaultEncoding", _webDefaultEncoding);
+                PechkinStatic.SetObjectSetting(config, "web.defaultEncoding", _webDefaultEncoding);
             }
             if (_webUserStylesheetUri != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "web.userStyleSheet", _webUserStylesheetUri);
+                PechkinStatic.SetObjectSetting(config, "web.userStyleSheet", _webUserStylesheetUri);
             }
             if (_webEnablePlugins != null)
             {
-                PechkinBindings.wkhtmltopdf_set_object_setting(config, "web.enablePlugins", _webEnablePlugins);
+                PechkinStatic.SetObjectSetting(config, "web.enablePlugins", _webEnablePlugins);
             }
 
             _header.SetUpObjectConfig(config, "header");

--- a/Pechkin/PechkinBindings.cs
+++ b/Pechkin/PechkinBindings.cs
@@ -4,8 +4,22 @@ using Pechkin.Util;
 
 namespace Pechkin
 {
+    [Serializable]
     internal static class PechkinBindings
     {
+        public static StringCallback warning_callback;
+
+        public static StringCallback error_callback;
+
+        public static VoidCallback phase_changed_callback;
+
+        public static IntCallback progress_changed_callback;
+
+        public static IntCallback finished_callback;
+
+        [DllImport("kernel32", SetLastError = true)]
+        public static extern bool FreeLibrary(IntPtr hModule);
+
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern int wkhtmltopdf_init(int useGraphics);
 
@@ -27,23 +41,33 @@ namespace Pechkin
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern int wkhtmltopdf_set_global_setting(IntPtr settings,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]String name,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]String value);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]
+            String name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]
+            String value);
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern int wkhtmltopdf_get_global_setting(IntPtr settings,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]String name,
-            [In][Out] ref byte[] value, int valueSize);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]
+            String name,
+            [In]
+            [Out]
+            ref byte[] value, int valueSize);
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern int wkhtmltopdf_set_object_setting(IntPtr settings,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]String name,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]String value);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]
+            String name,
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]
+            String value);
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern int wkhtmltopdf_get_object_setting(IntPtr settings,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]String name,
-            [In][Out] ref byte[] value, int vs);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]
+            String name,
+            [In]
+            [Out]
+            ref byte[] value, int vs);
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern IntPtr wkhtmltopdf_create_converter(IntPtr globalSettings);
@@ -52,26 +76,32 @@ namespace Pechkin
         public static extern void wkhtmltopdf_destroy_converter(IntPtr converter);
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        public static extern void wkhtmltopdf_set_warning_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] StringCallback callback);
+        public static extern void wkhtmltopdf_set_warning_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)]
+                                                                   StringCallback callback);
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        public static extern void wkhtmltopdf_set_error_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] StringCallback callback);
+        public static extern void wkhtmltopdf_set_error_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)]
+                                                                 StringCallback callback);
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        public static extern void wkhtmltopdf_set_phase_changed_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] VoidCallback callback);
+        public static extern void wkhtmltopdf_set_phase_changed_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)]
+                                                                         VoidCallback callback);
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        public static extern void wkhtmltopdf_set_progress_changed_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] IntCallback callback);
+        public static extern void wkhtmltopdf_set_progress_changed_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)]
+                                                                            IntCallback callback);
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
-        public static extern void wkhtmltopdf_set_finished_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)] IntCallback callback);
+        public static extern void wkhtmltopdf_set_finished_callback(IntPtr converter, [MarshalAs(UnmanagedType.FunctionPtr)]
+                                                                    IntCallback callback);
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern int wkhtmltopdf_convert(IntPtr converter);
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern void wkhtmltopdf_add_object(IntPtr converter, IntPtr objectSettings,
-            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]String data);
+            [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Utf8Marshaler))]
+            String data);
 
         [DllImport("wkhtmltox0.dll", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.StdCall)]
         public static extern void wkhtmltopdf_add_object(IntPtr converter, IntPtr objectSettings, byte[] data);

--- a/PechkinTests/PechkinAbstractTests.cs
+++ b/PechkinTests/PechkinAbstractTests.cs
@@ -91,6 +91,7 @@ namespace PechkinTests
             string html = GetResourceString("PechkinTests.Resources.page.html");
 
             TConvType c = ProduceTestObject(new GlobalConfig());
+
             byte[] ret = c.Convert(html);
 
             Assert.NotNull(ret);


### PR DESCRIPTION
Wrap all calls to PechkinBindings in a separate AppDomain and unload the
webkit dll after disposing SimplePechkin.
